### PR TITLE
Updated styling for treasury

### DIFF
--- a/src/components/Forms/ConfirmationForm.tsx
+++ b/src/components/Forms/ConfirmationForm.tsx
@@ -39,7 +39,7 @@ export default function ConfirmationForm ({ starsForDust, stars, dust, onConfirm
     <Box className="logo-container">
       <Logo />
     </Box>
-    <Text className="value">{amount}.00</Text>
+    <Text className="value">{amount}.000</Text>
     <Box className="label">
       <Text className="wstr">WSTR</Text>
       <Balance amount={amount} label="WSTR" />

--- a/src/components/Header/HeaderBar.scss
+++ b/src/components/Header/HeaderBar.scss
@@ -33,7 +33,47 @@
 
   .treasury {
     background-color: $yellow;
-    margin-left: 8px;
+    text-align: center;
+    cursor: pointer;
+
+    .modal {
+      cursor: default;
+      
+      .message-container {
+        display: flex;
+        flex-direction: column;
+        // justify-content: space-between;
+        align-items: flex-start;
+        padding: 36px;
+        position: absolute;
+        width: 400px;
+        height: 320px;
+        left: 35px;
+        top: 86px;
+        background: #F3C263;
+        border-radius: 24px;
+        text-align: left;
+
+        .title {
+          font-size: 16px;
+          font-weight: 600;
+          line-height: 24px;
+          color: $steel-grey;
+          margin-bottom: 24px;
+        }
+
+        .message, .stars {
+          font-size: 24px;
+          font-weight: 600;
+          line-height: 32px;
+          color: $steel-grey;
+
+          .stars {
+            color: black;
+          }
+        }
+      }
+    }
   }
 
   .walletSection {

--- a/src/components/Header/HeaderBar.tsx
+++ b/src/components/Header/HeaderBar.tsx
@@ -1,15 +1,21 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { Link } from 'react-router-dom'
-import { Row, Text } from '@tlon/indigo-react';
+import { Box, Row, Text } from '@tlon/indigo-react';
 import { useStore } from '../../store'
 import Logo from '../Icons/Logo';
 import WalletDisplay, { WalletDisplayProps } from './WalletDisplay'
 
 import './HeaderBar.scss'
+import { formatComma } from '../../utils/text';
+import Modal from '../Modal';
 
 export default function HeaderBar (props: WalletDisplayProps) {
   const { treasuryBalance } = useStore((store: any) => store)
+  const balanceText = formatComma(treasuryBalance)
+  const [showTreasuryInfo, setShowTreasuryInfo] = useState(false)
+
+  const toggleShowTreasuryInfo = () => setShowTreasuryInfo(!showTreasuryInfo)
 
   return (
       <header className="homeHeader">
@@ -21,9 +27,16 @@ export default function HeaderBar (props: WalletDisplayProps) {
                     <p className="ml-0.5em">Star Market</p>
                   </div>
                 </Link>
-                <Row className="treasury pill-button">
-                  <Logo className="logo" />
-                  <Text className="ml-0.5em">{treasuryBalance}</Text>
+                <Row className="treasury pill-button ml-0.5em" onClick={toggleShowTreasuryInfo}>
+                  <Text className="ml-0.5em mr-0.5em">{balanceText}</Text>
+                  {showTreasuryInfo && <Modal hideModal={toggleShowTreasuryInfo}>
+                    <Box className="message-container">
+                      <Text className="title">Treasury</Text>
+                      <Text className="message">
+                        <Text className="stars">{balanceText} Stars</Text> are held by the Star Market Smart Contract.
+                      </Text>
+                    </Box>
+                  </Modal>}
                 </Row>
               </Row>
               <nav className="walletSection">

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -5,3 +5,5 @@ export const starDustLabel = (exchange: Exchange) => `${exchange === Exchange.st
 export const pluralize = (text: string, amount: number, canPluralize?: boolean) => amount === 1 || !canPluralize ? text : `${text}s`
 
 export const getExchangeRate = (starsForDust: boolean) => starsForDust ? '1 WSTR = 1.00 Star' : '1 Star = 1.00 WSTR'
+
+export const formatComma = (amount: number) => String(amount).replace(/\B(?=(?:\d{3})+(?!\d))/g, ',')


### PR DESCRIPTION
@g-a-v-i-n , I noticed that the `layout` class is pushing the form down pretty far on the page (this screenshot is my whole screen on a macbook pro) but didn't want to make any changes since that affects the whole site. I'll let you handle as you see fit. See attached screenshot.

<img width="1168" alt="Screen Shot 2021-10-06 at 9 52 04 PM" src="https://user-images.githubusercontent.com/7759384/136307859-b5ed8ac5-ada6-48d0-8052-42d9b8e3ff9b.png">
e 