### PR TITLE
Correct star supply to 65,280

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -36,7 +36,7 @@ export default function About() {
                         </tr>
                         <tr>
                                 <td>Max Supply</td>
-                                <td>65,218</td>
+                                <td>65,280</td>
                         </tr>
                         <tr>
                                 <td>Social</td>


### PR DESCRIPTION
The About page formerly said that there are 65,218 total stars but it should be 65,280. 