### PR TITLE
Fix issue #49: Treasury bubble off screen

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1111,6 +1111,12 @@ button:hover {
   text-align: left;
 }
 
+@media screen and (max-width: 767px) {
+  .message-container {
+    max-width: 250px;
+  }
+}
+
 .relative {
   position: relative;
 }


### PR DESCRIPTION

<img width="335" alt="Screenshot 2023-05-23 at 6 16 53 PM" src="https://github.com/urbit/star.market/assets/3984057/80a68efe-6c17-48ce-b673-415548b09e42">
Simple css fix to display properly on smaller devices