### PR TITLE
Gas estimation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starketplace",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import Container from './components/Container';
 
 const ETHERSCAN_API_KEY = 'BXEKQG3V5SSS57PUCHCIJJ3X8CMRYS4B6D'
 
+// ST: Wait time no longer displayed, keeping in case we feel like adding it back
 // const formatWait = (wait: number) => String(Math.round(wait * 100 / 60) / 100);
 
 const feeToInt = (f: number) => f < 1 ? 1 : Math.round(f);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import Container from './components/Container';
 
 const ETHERSCAN_API_KEY = 'BXEKQG3V5SSS57PUCHCIJJ3X8CMRYS4B6D'
 
-const formatWait = (wait: number) => String(Math.round(wait * 100 / 60) / 100);
+// const formatWait = (wait: number) => String(Math.round(wait * 100 / 60) / 100);
 
 const feeToInt = (f: number) => f < 1 ? 1 : Math.round(f);
 const feeToWei = (fee: number) => Web3.utils.toHex(Web3.utils.toWei(String(fee), 'gwei'))
@@ -54,26 +54,15 @@ const App = () => {
   const loadGasPrices = useCallback(async () => {
 
     try {
-      const [feeResponse, waitResponse] = await Promise.all([
-        fetch(`https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=${ETHERSCAN_API_KEY}`,
-          {
-            method: 'GET',
-            cache: 'no-cache',
-          }
-        ),
-        fetch(
-          'https://ethereum-api.xyz/gas-prices',
-          {
-            method: 'GET',
-            cache: 'no-cache',
-          }
-        )
-      ]);
-
-      const [feeJson, waitJson] = await Promise.all([
-        feeResponse.json(),
-        waitResponse.json()
-      ])
+      const feeResponse = await fetch(
+        `https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=${ETHERSCAN_API_KEY}`,
+        {
+          method: "GET",
+          cache: "no-cache",
+        }
+      );
+      
+      const feeJson = await  feeResponse.json()
 
       const suggestedBaseFeePerGas = Number(feeJson.result.suggestBaseFee);
 
@@ -84,21 +73,21 @@ const App = () => {
       setSuggestedGasPrices({
         fast: {
           price: minGas(feeJson.result.FastGasPrice),
-          wait: formatWait(waitJson.result.fast.time),
+          wait: '1',
           maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.FastGasPrice - suggestedBaseFeePerGas),
           maxPriorityFeePerGas: feeToInt((feeJson.result.FastGasPrice - suggestedBaseFeePerGas)),
           suggestedBaseFeePerGas
         },
         average: {
           price: minGas(feeJson.result.ProposeGasPrice),
-          wait: formatWait(waitJson.result.average.time),
+          wait: '1',
           maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.ProposeGasPrice - suggestedBaseFeePerGas),
           maxPriorityFeePerGas: feeToInt((feeJson.result.ProposeGasPrice - suggestedBaseFeePerGas)),
           suggestedBaseFeePerGas
         },
         low: {
           price: minGas(feeJson.result.SafeGasPrice),
-          wait: formatWait(waitJson.result.slow.time),
+          wait: '1',
           maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.SafeGasPrice - suggestedBaseFeePerGas),
           maxPriorityFeePerGas: feeToInt((feeJson.result.SafeGasPrice - suggestedBaseFeePerGas)),
           suggestedBaseFeePerGas

--- a/src/components/Forms/FeeDropdown.tsx
+++ b/src/components/Forms/FeeDropdown.tsx
@@ -8,7 +8,8 @@ import { GasPrice } from '../../types/SuggestedGasPrices';
 
 const PRICE_LABELS = ['Fast', 'Average', 'Slow'];
 
-export const formatWait = (wait: number) => Math.round(wait * 100) / 100;
+// ST: wait time no longer displayed, keeping in case we feel like adding it back
+// export const formatWait = (wait: number) => Math.round(wait * 100) / 100;
 export const formatDisplay = ({ price, wait }: GasPrice) =>
   `${price} gwei`;
 

--- a/src/components/Forms/FeeDropdown.tsx
+++ b/src/components/Forms/FeeDropdown.tsx
@@ -10,7 +10,7 @@ const PRICE_LABELS = ['Fast', 'Average', 'Slow'];
 
 export const formatWait = (wait: number) => Math.round(wait * 100) / 100;
 export const formatDisplay = ({ price, wait }: GasPrice) =>
-  `${price} gwei (${wait} min)`;
+  `${price} gwei`;
 
 export default function FeeDropdown() {
   const { suggestedGasPrices, setGasPrice } = useStore();


### PR DESCRIPTION
- The gas price estimation made 2 api calls, one for the price and another for an estimated wait time. The wait time url "https://ethereum-api.xyz/gas-prices" no longer appears to be working, so this made the gas price call fail as well.

- Fixed by no longer trying to fetch wait time and removed it from being displayed on the UI (IMO it's not needed since Metamask will calculate this anyway.) Now the gas price estimate works as expected.
